### PR TITLE
Replaced the mysql query to delete attachments with wp_delete_attachm…

### DIFF
--- a/woocommerce-remove-all-products/woocommerce-remove-all-products.php
+++ b/woocommerce-remove-all-products/woocommerce-remove-all-products.php
@@ -201,11 +201,12 @@ function wc_remove_all_products_display_default_tab() {
 					$attachments_ids = get_posts( $args );
 
 					if ( ! empty( $attachments_ids ) ) {
-
-						$images_removed += count( $attachments_ids );
-
-						$delete_attachments_query = $wpdb->prepare( 'DELETE FROM %1$s WHERE ID IN (%2$s)', $wpdb->posts, implode( ',', $attachments_ids ) );
-						$wpdb->query( $delete_attachments_query );
+						
+			  			foreach ($attachments_ids as $attachment_id) {
+							wp_delete_attachment($attachment_id);
+						}
+						
+						$images_removed += count( $attachments_ids );	
 
 					}
 


### PR DESCRIPTION
I replaced the WPDB query with the wp native function wp_delete_attachment(). Mainly it fix a problem because attachments data aren't only into post table and so removing the post will not remove all attachment informations. For example, into wp_postmeta where meta_key = wp_attached_file ) there are informations about the filename.
Also, if there are plugins that hook or filter the wp_delete_attachment() function with the mysql query we do not trigger it (I think we would like to do it instead).